### PR TITLE
Make CodeSniffer installer OS independend in case of directory separator

### DIFF
--- a/SimplyAdmire/ComposerPlugins/Installers/PhpCodesnifferStandardInstaller.php
+++ b/SimplyAdmire/ComposerPlugins/Installers/PhpCodesnifferStandardInstaller.php
@@ -7,11 +7,14 @@ use Composer\Installer\LibraryInstaller;
 class PhpCodesnifferStandardInstaller extends LibraryInstaller {
 
 	public function getPackageBasePath(PackageInterface $package) {
-		$targetPathParts = explode('/', parent::getPackageBasePath($package));
+		$targetPathParts = explode(DIRECTORY_SEPARATOR, parent::getPackageBasePath($package));
 		$targetPathParts = array_splice($targetPathParts, 0, -2);
-		$targetPath = '/' . implode('/', $targetPathParts) . '/squizlabs/php_codesniffer/CodeSniffer/Standards/';
+		$targetPath  = DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $targetPathParts);
 
-		$packageKeyParts = explode('/', $package->getPrettyName(), 2);
+		$csPathParts = array('squizlabs', 'php_codesniffer', 'CodeSniffer', 'Standards');
+		$targetPath .= DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $csPathParts) . DIRECTORY_SEPARATOR;
+
+		$packageKeyParts = explode(DIRECTORY_SEPARATOR, $package->getPrettyName(), 2);
 
 		$codeStandardName = str_replace('Typo3', 'TYPO3', ucfirst($packageKeyParts[1]));
 		$codeStandardName = preg_replace_callback('/-([a-z]{1})/', function($matches) { return strtoupper($matches[1]); }, $codeStandardName);


### PR DESCRIPTION
In the PHP_CodeSniffer project for TYPO3 we got an error that the TYPO3SniffPool is not installable on windows.

Here is the ticket: https://forge.typo3.org/issues/58190

It seems to be an error because of the hardcoded directory separator "/".
This PR uses the PHP Constants DIRECTORY_SEPARATOR to be OS independent.

ATTENTION!
This PR is not tested on Windows.
