### PR TITLE
Adjust the installer to PHPCS 3.0

### DIFF
--- a/SimplyAdmire/ComposerPlugins/Installers/PhpCodesnifferStandardInstaller.php
+++ b/SimplyAdmire/ComposerPlugins/Installers/PhpCodesnifferStandardInstaller.php
@@ -19,7 +19,7 @@ class PhpCodesnifferStandardInstaller extends LibraryInstaller {
 
 		$targetPath = $this->vendorDir ? $this->vendorDir . '/' : '';
 
-		$codeSnifferStandardsPathParts = array('squizlabs', 'php_codesniffer', 'CodeSniffer', 'Standards');
+		$codeSnifferStandardsPathParts = array('squizlabs', 'php_codesniffer', 'src', 'Standards');
 		$targetPath .= implode(DIRECTORY_SEPARATOR, $codeSnifferStandardsPathParts) . DIRECTORY_SEPARATOR;
 
 		$packageKeyParts = explode('/', $package->getPrettyName(), 2);


### PR DESCRIPTION
The version 3.0 is alpha and far away from release. Maybe this PR can go into a 3.0 branch, so I can require that branch in the composer.json.
