### PR TITLE
Revert "[TASK] Adapt to deprecated excludeClasses in Flow"

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,0 +1,5 @@
+TYPO3:
+  Flow:
+    object:
+      excludeClasses:
+        'simplyadmire.composerplugins': ['.*']


### PR DESCRIPTION
This reverts commit 9b5d5a1819583deaa1f054ba5b8c190b492bbcbf.

This is done since the package is used in many existing Neos 1.2 installations that break when they do a composer update due to not being locked on a specific version. The reason for removing this configuration was to avoid a deprecation log entry, however since this package is no longer part of new
installations but installed separately from Flow that is no longer a problem.